### PR TITLE
Allow configure to work with non-bash shells

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,8 +26,8 @@ AC_CHECK_DECLS([thread_policy_set], [], [], [[
 
 AC_CONFIG_HEADERS([config.h])
 
-t=`$OCAMLBUILD -use-ocamlfind &> /dev/null; echo $?`
-if test $t == 0 ; then
+t=`$OCAMLBUILD -use-ocamlfind > /dev/null 2>&1 ; echo $?`
+if test "$t" = 0 ; then
   AC_MSG_RESULT(ocaml version $OCAMLVERSION. Use standard Makefile)
   AC_CONFIG_FILES([Makefile])
   AC_OUTPUT


### PR DESCRIPTION
Simpler shells (such as Debian's Dash) are increasingly used as /bin/sh.
Those shells implement the POSIX shell specification and very little
else.  Therefore, Bash-specific extensions prevent configure from
running correctly.

https://bugs.gentoo.org/553596

Signed-off-by: Rémi Cardona <remi@gentoo.org>