### PR TITLE
Support staged installation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -12,14 +12,6 @@ PREFIX = @prefix@
 MANDIR = @mandir@/man3
 LIBDIR = $(shell ocamlfind printconf destdir)
 
-ifeq ($(DESTDIR),)
-INSTALL = $(OCAMLFIND) install
-UNINSTALL = $(OCAMLFIND) remove
-else
-INSTALL = $(OCAMLFIND) install -destdir $(LIBDIR)
-UNINSTALL = $(OCAMLFIND) remove -destdir $(LIBDIR)
-endif
-
 
 ifeq ("@OCAMLBEST@","opt")
   OCAMLBEST=native
@@ -76,16 +68,16 @@ INSTALL_STUFF += $(filter-out $(wildcard _build/myocamlbuild.*),$(wildcard _buil
 INSTALL_STUFF += $(wildcard _build/*.so _build/*.a)
 
 install: $(LIBS) META
-	mkdir -p $(LIBDIR)
-	mkdir -p $(LIBDIR)/stublibs
-	$(INSTALL) -patch-version $(VERSION) $(NAME) $(INSTALL_STUFF)
+	mkdir -p $(DESTDIR)$(LIBDIR)
+	mkdir -p $(DESTDIR)$(LIBDIR)/stublibs
+	$(OCAMLFIND) install -destdir $(DESTDIR)$(LIBDIR) -patch-version $(VERSION) $(NAME) $(INSTALL_STUFF)
 	(cd _build; ocamldoc -man -man-mini parmap.ml parmap.mli)
-	mkdir -p $(PREFIX)$(MANDIR)
-	cp -p _build/Parmap.3o $(PREFIX)$(MANDIR)
+	mkdir -p $(DESTDIR)$(PREFIX)$(MANDIR)
+	cp -p _build/Parmap.3o $(DESTDIR)$(PREFIX)$(MANDIR)
 
 uninstall:
-	$(UNINSTALL) $(NAME)
-	rm -f $(PREFIX)$(MANDIR)/Parmap.3o
+	$(OCAMLFIND) remove -destdir $(DESTDIR)$(LIBDIR) $(NAME)
+	rm -f $(DESTDIR)$(PREFIX)$(MANDIR)/Parmap.3o
 
 doc:
 	$(OCAMLBUILD) $(OBFLAGS) $(NAME).docdir/index.html $(NAME).docdir/index.dot

--- a/Makefile.in
+++ b/Makefile.in
@@ -72,12 +72,12 @@ install: $(LIBS) META
 	mkdir -p $(DESTDIR)$(LIBDIR)/stublibs
 	$(OCAMLFIND) install -destdir $(DESTDIR)$(LIBDIR) -patch-version $(VERSION) $(NAME) $(INSTALL_STUFF)
 	(cd _build; ocamldoc -man -man-mini parmap.ml parmap.mli)
-	mkdir -p $(DESTDIR)$(PREFIX)$(MANDIR)
-	cp -p _build/Parmap.3o $(DESTDIR)$(PREFIX)$(MANDIR)
+	mkdir -p $(DESTDIR)$(MANDIR)
+	cp -p _build/Parmap.3o $(DESTDIR)$(MANDIR)
 
 uninstall:
 	$(OCAMLFIND) remove -destdir $(DESTDIR)$(LIBDIR) $(NAME)
-	rm -f $(DESTDIR)$(PREFIX)$(MANDIR)/Parmap.3o
+	rm -f $(DESTDIR)$(MANDIR)/Parmap.3o
 
 doc:
 	$(OCAMLBUILD) $(OBFLAGS) $(NAME).docdir/index.html $(NAME).docdir/index.dot

--- a/Makefile.in
+++ b/Makefile.in
@@ -9,16 +9,15 @@ OCAMLFIND=@OCAMLFIND@
 OCAMLBUILD=@OCAMLBUILD@
 
 PREFIX = @prefix@
+MANDIR = @mandir@/man3
 
 ifeq ($(DESTDIR),)
 LIBDIR=$(shell ocamlfind printconf destdir)
-MANDIR=@mandir@/man3
 INSTALL = $(OCAMLFIND) install
 UNINSTALL = $(OCAMLFIND) remove
 else
 export OCAMLLIBDIR := lib/ocaml
 LIBDIR=$(DESTDIR)/$(OCAMLLIBDIR)
-MANDIR=$(DESTDIR)/man/man3
 INSTALL = $(OCAMLFIND) install -destdir $(LIBDIR)
 UNINSTALL = $(OCAMLFIND) remove -destdir $(LIBDIR)
 endif
@@ -83,12 +82,12 @@ install: $(LIBS) META
 	test -d $(LIBDIR)/stublibs || mkdir -p $(LIBDIR)/stublibs
 	$(INSTALL) -patch-version $(VERSION) $(NAME) $(INSTALL_STUFF)
 	(cd _build; ocamldoc -man -man-mini parmap.ml parmap.mli)
-	test -d $(MANDIR) || mkdir -p $(MANDIR)
-	cp -p _build/Parmap.3o $(MANDIR)
+	test -d $(PREFIX)$(MANDIR) || mkdir -p $(PREFIX)$(MANDIR)
+	cp -p _build/Parmap.3o $(PREFIX)$(MANDIR)
 
 uninstall:
 	$(UNINSTALL) $(NAME)
-	rm -f $(MANDIR)/Parmap.3o
+	rm -f $(PREFIX)$(MANDIR)/Parmap.3o
 
 doc:
 	$(OCAMLBUILD) $(OBFLAGS) $(NAME).docdir/index.html $(NAME).docdir/index.dot

--- a/Makefile.in
+++ b/Makefile.in
@@ -78,11 +78,11 @@ INSTALL_STUFF += $(filter-out $(wildcard _build/myocamlbuild.*),$(wildcard _buil
 INSTALL_STUFF += $(wildcard _build/*.so _build/*.a)
 
 install: $(LIBS) META
-	test -d $(LIBDIR) || mkdir -p $(LIBDIR)
-	test -d $(LIBDIR)/stublibs || mkdir -p $(LIBDIR)/stublibs
+	mkdir -p $(LIBDIR)
+	mkdir -p $(LIBDIR)/stublibs
 	$(INSTALL) -patch-version $(VERSION) $(NAME) $(INSTALL_STUFF)
 	(cd _build; ocamldoc -man -man-mini parmap.ml parmap.mli)
-	test -d $(PREFIX)$(MANDIR) || mkdir -p $(PREFIX)$(MANDIR)
+	mkdir -p $(PREFIX)$(MANDIR)
 	cp -p _build/Parmap.3o $(PREFIX)$(MANDIR)
 
 uninstall:

--- a/Makefile.in
+++ b/Makefile.in
@@ -10,14 +10,12 @@ OCAMLBUILD=@OCAMLBUILD@
 
 PREFIX = @prefix@
 MANDIR = @mandir@/man3
+LIBDIR = $(shell ocamlfind printconf destdir)
 
 ifeq ($(DESTDIR),)
-LIBDIR=$(shell ocamlfind printconf destdir)
 INSTALL = $(OCAMLFIND) install
 UNINSTALL = $(OCAMLFIND) remove
 else
-export OCAMLLIBDIR := lib/ocaml
-LIBDIR=$(DESTDIR)/$(OCAMLLIBDIR)
 INSTALL = $(OCAMLFIND) install -destdir $(LIBDIR)
 UNINSTALL = $(OCAMLFIND) remove -destdir $(LIBDIR)
 endif

--- a/Makefile.in
+++ b/Makefile.in
@@ -8,20 +8,16 @@ LDFLAGS=@LDFLAGS@
 OCAMLFIND=@OCAMLFIND@
 OCAMLBUILD=@OCAMLBUILD@
 
-datarootdir = @datarootdir@
-prefix = @prefix@
-exec_prefix = @exec_prefix@
+PREFIX = @prefix@
 
 ifeq ($(DESTDIR),)
 LIBDIR=$(shell ocamlfind printconf destdir)
-BINDIR=@bindir@
 MANDIR=@mandir@/man3
 INSTALL = $(OCAMLFIND) install
 UNINSTALL = $(OCAMLFIND) remove
 else
 export OCAMLLIBDIR := lib/ocaml
 LIBDIR=$(DESTDIR)/$(OCAMLLIBDIR)
-BINDIR=$(DESTDIR)/bin
 MANDIR=$(DESTDIR)/man/man3
 INSTALL = $(OCAMLFIND) install -destdir $(LIBDIR)
 UNINSTALL = $(OCAMLFIND) remove -destdir $(LIBDIR)


### PR DESCRIPTION
Hello,

In order to package parmap in pkgsrc, it needs to support "staged installation" (installing into DESTDIR). For example:

```
./configure --prefix=$HOME
make
mkdir .destdir
DESTDIR=$(pwd)/.destdir make install
```

This should install everything into the .destdir directory like so:

```
.destdir/home/foo/lib/ocaml/site-lib/parmap
.destdir/home/foo/share/man/man3
```

but at the moment it's not working.

I changed a few things in the file Makefile.in to do this properly. I removed the test for DESTDIR since it is not set during the build target but during the install target; and I changed the install target to always install to $(DESTDIR)$(PREFIX); if DESTDIR is not set this will evaluate to $(PREFIX) as usual.
