### PR TITLE
can_redirect: don't treat mkdir returning EEXIST as an error

### DIFF
--- a/parmap.ml
+++ b/parmap.ml
@@ -42,10 +42,14 @@ let can_redirect path =
     try
       Unix.mkdir path 0o777; true
     with Unix.Unix_error(e,_s,_s') ->
-      (Printf.eprintf "[Pid %d]: Error creating %s : %s; proceeding without \
-                       stdout/stderr redirection\n%!"
-	 (Unix.getpid ()) path (Unix.error_message e));
-      false
+      (* another job may have created it between the check and the mkdir *)
+      if e == Unix.EEXIST then true
+      else begin
+	      (Printf.eprintf "[Pid %d]: Error creating %s : %s; proceeding \
+			       without stdout/stderr redirection\n%!"
+		 (Unix.getpid ()) path (Unix.error_message e));
+	      false
+	end
   else true
 
 let log_debug fmt =


### PR DESCRIPTION
can_redirect's test for existance of the path followed by the mkdir
is inherently racy.  It's trivially possible to encounter a situation
where the test for existance fails in two processes and one of them
succeeds in creating the directory.  Since both processes are
looking to create and use the directory for the same purpose, we
don't need to treat EEXIST as an error.