### PR TITLE
added test for ocamlbuild

### DIFF
--- a/configure
+++ b/configure
@@ -3047,6 +3047,9 @@ fi
 if test "$OCAMLC" = "no"; then
  as_fn_error $? "You must install the OCaml compiler" "$LINENO" 5
 fi
+if test "$OCAMLBUILD" = "no"; then
+ as_fn_error $? "You must install OCamlbuild (the ocamlbuild command)" "$LINENO" 5
+fi
 
 
   # checking for ocamlfind

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,9 @@ AC_PROG_OCAML
 if test "$OCAMLC" = "no"; then
  AC_MSG_ERROR([You must install the OCaml compiler])
 fi
+if test "$OCAMLBUILD" = "no"; then
+ AC_MSG_ERROR([You must install OCamlbuild (the ocamlbuild command)])
+fi
 
 AC_PROG_FINDLIB
 AC_SUBST(OCAMLFIND)


### PR DESCRIPTION
parmap relies on ocamlbuild, so when the configure script detects
that ocamlbuid does not exist, it should report an error.
fix #78 