### PR TITLE
Optimize setcore on single core systems

### DIFF
--- a/src/setcore_stubs.c
+++ b/src/setcore_stubs.c
@@ -29,6 +29,8 @@ CAMLprim value setcore(value which) {
 #endif
   int retcode;
   int finished=0;
+  if (numcores <= 1) // only one core in the system, no need to attempt pinning
+    return Val_unit;
   while (finished==0)
     {
 #if HAVE_DECL_SCHED_SETAFFINITY


### PR DESCRIPTION
In case the system has only a single core/processor, then attempting to pin is kinda pointless, as the result will not change.

Hence, make the C setcore stub almost a no-op in case there is only one core available.