### PR TITLE
fix build on windows

### DIFF
--- a/src/setcore_stubs.c
+++ b/src/setcore_stubs.c
@@ -12,14 +12,26 @@
 #include <unistd.h>
 #include <errno.h>
 #include <caml/mlvalues.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
+static int get_numcores() {
+#ifdef _WIN32
+  SYSTEM_INFO sysinfo;
+  GetSystemInfo(&sysinfo);
+  return sysinfo.dwNumberOfProcessors;
+#else
+  return sysconf( _SC_NPROCESSORS_ONLN );
+#endif
+}
 CAMLprim value numcores(value unit) {
-  int numcores = sysconf( _SC_NPROCESSORS_ONLN );
+  int numcores = get_numcores();
   return Val_int(numcores);
 }
 
 CAMLprim value setcore(value which) {
-  int numcores = sysconf( _SC_NPROCESSORS_ONLN );
+  int numcores = get_numcores();
   int w = Int_val(which) % numcores; // stay in the space of existing cores
 #if HAVE_DECL_SCHED_SETAFFINITY
   cpu_set_t cpus;   


### PR DESCRIPTION
This patch allows parmap to build on Windows, but not to run on Windows as there is no `Unix.fork`.

I have no idea if it's possible to make it fully work on Windows at all, using `ZwCreateProcess` is possible and I was able to make it work, but it's an NT API and that's hackish as it can get.

So with this libraries can still use parmap but just add an `if Sys.win32` to not use parmap when it's Windows