### PR TITLE
silence the -unerasable-optional-argument warning about Parmap.redirect

### DIFF
--- a/src/parmap.ml
+++ b/src/parmap.ml
@@ -102,7 +102,8 @@ let reopen_out outchan path fname =
 
 (* send stdout and stderr to a file to avoid mixing output from different
    cores, if enabled *)
-let redirect ?(path = (Printf.sprintf "/tmp/.parmap.%d" (Unix.getpid ()))) ~id =
+let[@warning "-16" (*unerasable-optional-argument*)]
+  redirect ?(path = (Printf.sprintf "/tmp/.parmap.%d" (Unix.getpid ()))) ~id =
       reopen_out stdout path (Printf.sprintf "stdout.%d" id);
       reopen_out stderr path (Printf.sprintf "stderr.%d" id);;
 


### PR DESCRIPTION
Parmap.redirect, introduced in 236137fb12dd84b8d60bd7f6f9496d6032f85df2, has an optional argument that is not followed by any non-labelled argument. With this interface, OCaml can never deduce that the optional argument will never be passed by the user, so users have to use ?path:None explicitly to not pass a path.

One could fix this issue by making `~id` a non-labelled argument, or by adding a dummy unit argument at the end.

The present commit simply silences the warning, which restores the build under OCaml 4.12 and later versions. The reason why this code only started failing in 4.12 is that the pre-4.12 implementation of the unerasable-optional-argument warning did not detect this case, and the warning check was widened for 4.12 by
  https://github.com/ocaml/ocaml/pull/9783

Ideally it would be nice to change the interface of Parmap.redirect, but this would be an API-breaking change.