### PR TITLE
codemeta.json: Fix ORCID URLs for authors

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -24,7 +24,7 @@
     "author": [
         {
             "@type": "Person",
-            "@id": "https://orcid.org/ 0000-0002-7493-5349",
+            "@id": "https://orcid.org/0000-0002-7493-5349",
             "givenName": "Roberto",
             "familyName": "Di Cosmo",
             "email": "roberto@dicosmo.org",
@@ -35,7 +35,7 @@
         },
         {
             "@type": "Person",
-            "@id": "https://orcid.org/ 0000-0002-7433-376X",
+            "@id": "https://orcid.org/0000-0002-7433-376X",
             "givenName": "Marco",
             "familyName": "Danelutto",
             "email": "marco.danelutto@unipi.it",


### PR DESCRIPTION
Due to a spurious space character the URLs were invalid and it could lead to invalid parsing of the metadata (python rdflib return a null author list when ORCID URLs are invalid for instance).