### PR TITLE
setcore: avoid infinite loop when core pinning always fails (#103)

### DIFF
--- a/src/setcore_stubs.c
+++ b/src/setcore_stubs.c
@@ -43,7 +43,7 @@ CAMLprim value setcore(value which) {
   int finished=0;
   if (numcores <= 1) // only one core in the system, no need to attempt pinning
     return Val_unit;
-  while (finished==0)
+  do
     {
 #if HAVE_DECL_SCHED_SETAFFINITY
       CPU_ZERO(&cpus); 
@@ -72,5 +72,6 @@ CAMLprim value setcore(value which) {
 	  finished=1;
 	}
     }
+  while (finished==0 && w>0);
   return Val_unit;
 }


### PR DESCRIPTION
## Summary

- Bound the `setcore` retry loop so a permanent core-pinning failure no longer hangs the worker.
- Pure logic change (`while (finished==0)` → `do { … } while (finished==0 && w>0)`); no refactoring, no whitespace noise.

## Context

`setcore` halves `w` every time the OS rejects the affinity request. On platforms where pinning to core 0 also fails (observed on Apple M1 / Homebrew), `w` reaches 0 and the unbounded loop spins forever — see #103, returntocorp/semgrep#2432, facebook/infer#1410.

Original analysis and patch by @IagoAbal in #104; this PR carries just the logic change he was asked to extract back in 2021. PR #104 can be closed in favor of this.

## Test plan

- [x] `dune build @install` passes locally (Linux x86_64, OCaml 5).
- [x] `dune runtest` passes locally (full suite, including `simplescale*` and `floatscale`).
- [ ] Re-confirmation on Apple M1 that the previously-hanging input no longer hangs (cannot test from this machine).

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)