### PR TITLE
parmap: skip fork when ~ncores=1 (#77)

### DIFF
--- a/src/parmap.ml
+++ b/src/parmap.ml
@@ -301,6 +301,16 @@ let setup_children_chans oc pipedown ?fdarr i =
 let mapper (init:int -> unit) (finalize:unit -> unit) ncores' ~chunksize compute opid al collect =
   let ln = Array.length al in
   if ln=0 then (collect []) else
+  if ncores' <= 1 then begin
+    (* Single-core: run in-process, no fork (issue #77).
+       init/finalize are intentionally skipped: with no child process there
+       is nothing to initialise. *)
+    ignore init; ignore finalize;
+    set_ncores 1;
+    log_debug "mapper on %d elements, single-core in-process (no fork)%!" ln;
+    let exc_handler e _ = raise e in
+    collect [compute al 0 (ln-1) opid exc_handler]
+  end else
   begin
    set_ncores (min ln (max 1 ncores'));
    log_debug "mapper on %d elements, on %d cores%!" ln !ncores;
@@ -410,6 +420,14 @@ let mapper (init:int -> unit) (finalize:unit -> unit) ncores' ~chunksize compute
 let geniter init finalize ncores' ~chunksize compute al =
   let ln = Array.length al in
   if ln=0 then () else
+  if ncores' <= 1 then begin
+    (* Single-core: run in-process, no fork (issue #77). *)
+    ignore init; ignore finalize;
+    set_ncores 1;
+    log_debug "geniter on %d elements, single-core in-process (no fork)%!" ln;
+    let exc_handler e _ = raise e in
+    compute al 0 (ln-1) exc_handler
+  end else
   begin
    set_ncores (min ln (max 1 ncores'));
    log_debug "geniter on %d elements, on %d cores%!" ln !ncores;

--- a/tests/dune
+++ b/tests/dune
@@ -14,9 +14,9 @@
 
 (tests
  (names testexceptions simplescale simplescale_array simplescalefold
-   simplescalemapfold)
+   simplescalemapfold testncores1)
  (modules testexceptions simplescale simplescale_array simplescalefold
-   simplescalemapfold)
+   simplescalemapfold testncores1)
  (flags
   (:standard -w -35-27))
  (libraries utils parmap))

--- a/tests/testncores1.ml
+++ b/tests/testncores1.ml
@@ -1,0 +1,106 @@
+(**************************************************************************)
+(* Issue #77: when ~ncores=1 (or 0), Parmap should not fork.              *)
+(*                                                                        *)
+(* The check is indirect but reliable: we use a parent-side ref counter   *)
+(* whose increments only persist if the closure runs in the parent. If    *)
+(* Parmap forked, the children's increments would be invisible to us.    *)
+(**************************************************************************)
+
+open Parmap
+
+let l = [1;2;3;4;5]
+let expected_sum = List.fold_left (+) 0 l
+
+let assert_no_fork tag counter =
+  if !counter <> List.length l then begin
+    Printf.eprintf
+      "FAIL [%s]: expected counter=%d (in-process), got %d (fork happened?)\n%!"
+      tag (List.length l) !counter;
+    exit 1
+  end
+
+let () =
+  (* parmap, ~ncores:1 *)
+  let counter = ref 0 in
+  let r = parmap ~ncores:1 (fun x -> incr counter; x*2) (L l) in
+  assert (r = List.map (fun x -> x*2) l);
+  assert_no_fork "parmap ~ncores:1" counter;
+
+  (* parmap, ~ncores:0 (clamped, also no fork) *)
+  let counter = ref 0 in
+  let r = parmap ~ncores:0 (fun x -> incr counter; x*2) (L l) in
+  assert (r = List.map (fun x -> x*2) l);
+  assert_no_fork "parmap ~ncores:0" counter;
+
+  (* parmapi *)
+  let counter = ref 0 in
+  let r = parmapi ~ncores:1 (fun i x -> incr counter; (i,x)) (L l) in
+  assert (r = List.mapi (fun i x -> (i,x)) l);
+  assert_no_fork "parmapi ~ncores:1" counter;
+
+  (* pariter *)
+  let counter = ref 0 in
+  pariter ~ncores:1 (fun _ -> incr counter) (L l);
+  assert_no_fork "pariter ~ncores:1" counter;
+
+  (* parfold *)
+  let counter = ref 0 in
+  let r = parfold ~ncores:1 (fun x acc -> incr counter; x + acc) (L l) 0 (+) in
+  assert (r = expected_sum);
+  assert_no_fork "parfold ~ncores:1" counter;
+
+  (* parmapfold *)
+  let counter = ref 0 in
+  let r =
+    parmapfold ~ncores:1
+      (fun x -> incr counter; x*10)
+      (L l)
+      (fun mapped acc -> mapped + acc)
+      0
+      (+)
+  in
+  assert (r = expected_sum * 10);
+  assert_no_fork "parmapfold ~ncores:1" counter;
+
+  (* array_parmap *)
+  let counter = ref 0 in
+  let r = array_parmap ~ncores:1 (fun x -> incr counter; x+1) [|1;2;3|] in
+  assert (r = [|2;3;4|]);
+  assert (!counter = 3);
+
+  (* array_float_parmap *)
+  let counter = ref 0 in
+  let r = array_float_parmap ~ncores:1 (fun x -> incr counter; x +. 0.5) [|1.0;2.0;3.0|] in
+  assert (r.(0) = 1.5 && r.(1) = 2.5 && r.(2) = 3.5);
+  assert (!counter = 3);
+
+  (* init/finalize must NOT be called when ncores=1 (no child to set up) *)
+  let init_called = ref false in
+  let finalize_called = ref false in
+  let _ =
+    parmap
+      ~init:(fun _ -> init_called := true)
+      ~finalize:(fun () -> finalize_called := true)
+      ~ncores:1
+      (fun x -> x)
+      (L l)
+  in
+  assert (not !init_called);
+  assert (not !finalize_called);
+
+  (* Exceptions raised in user code must propagate to the caller, not exit. *)
+  let raised = ref false in
+  (try
+     ignore (parmap ~ncores:1 (fun _ -> failwith "boom") (L l))
+   with Failure _ -> raised := true);
+  assert !raised;
+
+  (* get_ncores () should be 1 after a ~ncores:1 call *)
+  let _ = parmap ~ncores:1 (fun x -> x) (L l) in
+  assert (get_ncores () = 1);
+
+  (* Empty inputs still no-op (pre-existing behavior preserved) *)
+  assert (parmap ~ncores:1 (fun x -> x) (L []) = []);
+  assert (array_parmap ~ncores:1 (fun x -> x) [||] = [||]);
+
+  print_endline "OK"


### PR DESCRIPTION
## Summary

- Short-circuit the fork-and-mmap machinery when `~ncores <= 1` (also covers `~ncores:0`, previously clamped to 1).
- The change lives at the top of the internal dispatchers `mapper` and `geniter`, so it applies uniformly to **all** public combinators: `parmap*`, `parmapi*`, `pariter*`, `parfold*`, `parmapfold*`, `parmapifold*`, `array_parmap*`, `array_float_parmap*`.
- `init`/`finalize` are intentionally **not** called: with no child process to set up there is nothing to initialise, matching the "equivalent to `List.map`" expectation in the issue. Exceptions in `f` now propagate to the caller instead of `exit 1`-ing a worker.

## Why

Per @UnixJunkie in #77: "List.map is equivalent to Parmap.map ~ncores:1 and there is almost no overhead." Today, `Parmap.parmap ~ncores:1 f l` still forks a single child, sets affinity, mmaps a result buffer, marshals back, etc. — pure overhead. It also makes Parmap awkward to use in single-core test environments.

## Test plan

- [x] New `tests/testncores1.ml` confirms the no-fork path across `parmap`, `parmapi`, `pariter`, `parfold`, `parmapfold`, `array_parmap`, `array_float_parmap`. The reliable signal is a **parent-side ref counter**: if Parmap forked, the children's increments would be invisible to the parent; we assert the counter equals the input length, proving the closure ran in-process.
- [x] Asserts that `init` / `finalize` are not invoked at `~ncores:1`.
- [x] Asserts that exceptions raised in user code propagate as `Failure` to the caller (previously they would `exit 1` from a worker).
- [x] Asserts `get_ncores () = 1` after such a call.
- [x] Asserts empty-input behavior still no-ops.
- [x] Full existing suite (`dune runtest`) still passes; the existing `simplescale` benchmarks now report ~1× speedup at `ncores:1` (no fork tax).

Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)